### PR TITLE
Fix code scanning alert no. 73: Time-of-check time-of-use filesystem race condition

### DIFF
--- a/src/picoc/platform/platform_unix.c
+++ b/src/picoc/platform/platform_unix.c
@@ -1,3 +1,4 @@
+#include <fcntl.h>
 #include "../picoc.h"
 #include "../interpreter.h"
 

--- a/src/picoc/platform/platform_unix.c
+++ b/src/picoc/platform/platform_unix.c
@@ -92,15 +92,16 @@ char *PlatformReadFile(Picoc *pc, const char *FileName)
     if (FileName == NULL)
         ProgramFailNoParser(pc, "no filename set\n");
 
-    if (stat(FileName, &FileInfo))
+    int fd = open(FileName, O_RDONLY);
+    if (fd == -1)
         ProgramFailNoParser(pc, "can't read file %s\n", FileName);
 
-    InFile = fopen(FileName, "r");
+    if (fstat(fd, &FileInfo) != 0)
+        ProgramFailNoParser(pc, "can't get file info for %s\n", FileName);
+
+    InFile = fdopen(fd, "r");
     if (InFile == NULL)
         ProgramFailNoParser(pc, "can't read file %s\n", FileName);
-
-    if (fstat(fileno(InFile), &FileInfoAfterOpen) != 0 || FileInfo.st_ino != FileInfoAfterOpen.st_ino)
-        ProgramFailNoParser(pc, "file %s changed since last checked\n", FileName);
 
     ReadText = malloc(FileInfo.st_size + 1);
     if (ReadText == NULL)


### PR DESCRIPTION
Fixes [https://github.com/CANopenTerm/CANopenTerm/security/code-scanning/73](https://github.com/CANopenTerm/CANopenTerm/security/code-scanning/73)

To fix the TOCTOU race condition, we should avoid using `stat` and `fopen` separately. Instead, we can use `open` to get a file descriptor and then use `fdopen` to convert the file descriptor to a `FILE*`. This ensures that the file we operate on is the same file that was checked.

- Replace the `stat` and `fopen` calls with a single `open` call to obtain a file descriptor.
- Use `fstat` on the file descriptor to get file information.
- Use `fdopen` to convert the file descriptor to a `FILE*` for reading.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
