### PR TITLE
can_linux: initialize msghdr in a portable way

### DIFF
--- a/src/core/can_linux.c
+++ b/src/core/can_linux.c
@@ -359,11 +359,16 @@ static char** get_can_interfaces(int* count)
     int                fd;
     char               buf[BUFFER_SIZE] = { 0 };
     struct iovec       iov              = { buf, sizeof(buf) };
-    struct msghdr      msg              = { &sa, sizeof(sa), &iov, 1, NULL, 0, 0 };
+    struct msghdr      msg              = { 0 };
     int                len;
     int                max_interfaces   = 10;
     int                can_count        = 0;
     char**             can_interfaces   = (char**)os_calloc(max_interfaces * sizeof(char*), sizeof(char));
+    
+    msg.msg_name = &sa;
+    msg.msg_namelen = sizeof(sa);
+    msg.msg_iov = &iov;
+    msg.msg_iovlen = 1;
 
     struct
     {


### PR DESCRIPTION
musl has padding bytes inside the msghdr struct which means initializing full structure will cause wrong assignments, doing partial assignment is more portable and assign the elements after that

Fixes
src/core/can_linux.c:362:71: error: incompatible pointer to integer conversion initializing 'int' with an expression of type 'void *' [-Wint-conversion]
  |     struct msghdr      msg              = { &sa, sizeof(sa), &iov, 1, NULL, 0, 0 };
  |                                                                       ^~~~