### PR TITLE
Fix exe installation when BUILD_YOCTO is enabled

### DIFF
--- a/cmake/os_linux.cmake
+++ b/cmake/os_linux.cmake
@@ -104,10 +104,10 @@ if (BUILD_YOCTO)
             DESTINATION /usr/share/CANopenTerm/scripts/utils
             FILES_MATCHING PATTERN "*")
 
-    install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/CANopenTerm
+    install(PROGRAMS ${CMAKE_CURRENT_SOURCE_DIR}/export/CANopenTerm
             DESTINATION /usr/bin)
 
-    install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/codb2json
+    install(PROGRAMS ${CMAKE_CURRENT_SOURCE_DIR}/export/codb2json
             DESTINATION /usr/bin)
 
     return()


### PR DESCRIPTION
While building CanopenTerm in Buildroot, with the BUILD_YOCTO option enabled (yes, really :)), the following error is raised:

CMake Error at output/build/canopenterm-1.0.10/cmake_install.cmake:114 (file):
  file INSTALL cannot find
  "buildroot/output/build/canopenterm-1.0.10/CANopenTerm":
  No such file or directory.